### PR TITLE
Emits a ledger.transaction.updated event detailing the transaction

### DIFF
--- a/ledger-service/README.md
+++ b/ledger-service/README.md
@@ -6,7 +6,7 @@ and publishes events detailing the ledger with the newly created ledger entries.
 ## Manual testing
 
 A `transaction.created` event can be published to Kafka.
-This will be collected; entries will be created in the ledger table and `ledger.updated` events will be published.
+This will be collected; entries will be created in the ledger table and `ledger.updated` and `ledger.transaction.updated` events will be published.
 
 ```json
 {
@@ -48,5 +48,25 @@ And one for the member of the transaction:
 	"user_id": "6cd0703c-1e23-43c6-96c2-af043e6ad4bf",
     "participant_id": "460e1637-8c7d-48c4-9e3f-58e880f77fde",
 	"amount": 1
+}
+```
+
+One `ledger.transaction.updated` event will be published describing the transaction:
+
+This event contains only the positive values and does not contain the debits to the creator. 
+The amounts array contains only the ledger items from the creator of the transaction.
+
+```json
+{
+	"transaction_id": "c6037d00-88e2-4479-9468-fb79033fcd27",
+	"session_id": "5c0327eb-b934-46be-a882-56195fab04d9",
+	"user_id": "6cd0703c-1e23-43c6-96c2-af043e6ad4bf",
+	"total": 1,
+	"amounts": [
+		{
+			"user_id": "460e1637-8c7d-48c4-9e3f-58e880f77fde",
+			"amount": 1
+		}
+	]
 }
 ```

--- a/ledger-service/internal/event/event.go
+++ b/ledger-service/internal/event/event.go
@@ -26,3 +26,16 @@ type LedgerUpdatedEvent struct {
 	ParticipantID string  `json:"participant_id"`
 	Amount        float64 `json:"amount"`
 }
+
+type LedgerUpdateCompleteMemberAmount struct {
+	UserID string  `json:"user_id"`
+	Amount float64 `json:"amount"`
+}
+
+type LedgerTransactionUpdatedEvent struct {
+	TransactionID string                             `json:"transaction_id"`
+	SessionID     string                             `json:"session_id"`
+	UserID        string                             `json:"user_id"`
+	Total         float64                            `json:"total"`
+	Amounts       []LedgerUpdateCompleteMemberAmount `json:"amounts"`
+}

--- a/ledger-service/internal/publisher/ledger.transaction.updated.go
+++ b/ledger-service/internal/publisher/ledger.transaction.updated.go
@@ -1,0 +1,71 @@
+package publisher
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/segmentio/kafka-go"
+	"github.com/thisisthemurph/beerbux/ledger-service/internal/event"
+	"github.com/thisisthemurph/beerbux/ledger-service/internal/handler"
+)
+
+const TopicLedgerTransactionUpdated = "ledger.transaction.updated"
+
+type LedgerTransactionUpdatedPublisher interface {
+	Publish(ctx context.Context, ledgerItems []handler.MemberTransaction) error
+}
+
+type LedgerTransactionUpdatedKafkaPublisher struct {
+	writer *kafka.Writer
+}
+
+func NewLedgerTransactionUpdatedKafkaPublisher(brokers []string) LedgerTransactionUpdatedPublisher {
+	return &LedgerTransactionUpdatedKafkaPublisher{
+		writer: &kafka.Writer{
+			Addr:  kafka.TCP(brokers...),
+			Topic: TopicLedgerTransactionUpdated,
+		},
+	}
+}
+
+func (p *LedgerTransactionUpdatedKafkaPublisher) Publish(ctx context.Context, ledgerItems []handler.MemberTransaction) error {
+	transactionEvent := event.LedgerTransactionUpdatedEvent{}
+
+	for i, item := range ledgerItems {
+		if i == 0 {
+			transactionEvent.TransactionID = item.TransactionID
+			transactionEvent.SessionID = item.SessionID
+			transactionEvent.UserID = item.UserID
+			transactionEvent.Amounts = make([]event.LedgerUpdateCompleteMemberAmount, 0, len(ledgerItems))
+		}
+
+		// Add the amount to the total if the user is not the creator.
+		if item.UserID != transactionEvent.UserID {
+			transactionEvent.Total += item.Amount * -1 // The amount should be positive here as we are indicating transaction value.
+			transactionEvent.Amounts = append(transactionEvent.Amounts, event.LedgerUpdateCompleteMemberAmount{
+				UserID: item.UserID,
+				Amount: item.Amount * -1, // The amount should be positive here as we are indicating transaction value.
+			})
+		}
+	}
+
+	data, err := json.Marshal(transactionEvent)
+	if err != nil {
+		return fmt.Errorf("failed to marshal %v event %v: %w", p.writer.Topic, transactionEvent.TransactionID, err)
+	}
+
+	msg := kafka.Message{
+		Key:   []byte(transactionEvent.TransactionID),
+		Value: data,
+		Headers: []kafka.Header{
+			{"version", []byte("1.0.0")},
+			{"source", []byte("ledger-service")},
+		},
+	}
+
+	if err := p.writer.WriteMessages(ctx, msg); err != nil {
+		return fmt.Errorf("failed to publish %q message: %w", p.writer.Topic, err)
+	}
+
+	return nil
+}

--- a/webui/src/features/session/transaction/index.tsx
+++ b/webui/src/features/session/transaction/index.tsx
@@ -1,6 +1,6 @@
 import useSessionClient from "@/api/session-client.ts";
 import useTransactionClient from "@/api/transaction-client.ts";
-import { TransactionMemberAmounts } from "@/api/types.ts";
+import type { TransactionMemberAmounts } from "@/api/types.ts";
 import {
 	Card,
 	CardContent,


### PR DESCRIPTION
The ledger-service now emits a `ledger.transaction.updated` event detailing the transaction updated/calculated in the ledger.

This event details:
- the owner/creator of the transaction
- the session and transaction identifiers
- the total positive amount of the transaction
- the member ids in the transaction
- the amount transferred to each of the members in the transaction (summed will be the same as the total)